### PR TITLE
Solved https://github.com/zhou13/lcnn/issues/53#issue-1005072261

### DIFF
--- a/lcnn/models/line_vectorizer.py
+++ b/lcnn/models/line_vectorizer.py
@@ -171,7 +171,7 @@ class LineVectorizer(nn.Module):
 
             # index: [N_TYPE, K]
             score, index = torch.topk(jmap, k=K)
-            y = (index / 128).float() + torch.gather(joff[:, 0], 1, index) + 0.5
+            y = (index // 128).float() + torch.gather(joff[:, 0], 1, index) + 0.5
             x = (index % 128).float() + torch.gather(joff[:, 1], 1, index) + 0.5
 
             # xy: [N_TYPE, K, 2]


### PR DESCRIPTION
In PyTorch 1.4.x (index/128) at https://github.com/zhou13/lcnn/blob/88f281ab5421d51a62f1f84f97fea05afbf0c8d8/lcnn/models/line_vectorizer.py#L174 outputs integer values but in PyTorch 1.8.x it outputs float values. Updating it with (index//128) outputs integer values in both PyTorch versions and solves https://github.com/zhou13/lcnn/issues/53#issue-1005072261.